### PR TITLE
Fix optional unwrap error when calling removeFromSuperview

### DIFF
--- a/KDCircularProgress/KDCircularProgress.swift
+++ b/KDCircularProgress/KDCircularProgress.swift
@@ -228,8 +228,8 @@ public class KDCircularProgress: UIView {
     }
     
     public override func didMoveToWindow() {
-        if window != nil {
-            progressLayer.contentsScale = window!.screen.scale
+        if let window = window {
+            progressLayer.contentsScale = window.screen.scale
         }
     }
     

--- a/KDCircularProgress/KDCircularProgress.swift
+++ b/KDCircularProgress/KDCircularProgress.swift
@@ -228,7 +228,9 @@ public class KDCircularProgress: UIView {
     }
     
     public override func didMoveToWindow() {
-        progressLayer.contentsScale = window!.screen.scale
+        if window != nil {
+            progressLayer.contentsScale = window!.screen.scale
+        }
     }
     
     public override func willMoveToSuperview(newSuperview: UIView?) {


### PR DESCRIPTION
Added a check as `window` can be `nil` in `didMoveToWindow`, which causes an error when `removeFromSuperview` is called. (Source: [Apple](https://developer.apple.com/library/ios/documentation/UIKit/Reference/UIView_Class/#//apple_ref/occ/instm/UIView/didMoveToWindow))