### PR TITLE
Implemented init(coder:)

### DIFF
--- a/KDCircularProgress/KDCircularProgress.swift
+++ b/KDCircularProgress/KDCircularProgress.swift
@@ -154,9 +154,12 @@ public class KDCircularProgress: UIView {
     }
 
     required public init(coder aDecoder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-    
+		super.init(coder: aDecoder)
+		setTranslatesAutoresizingMaskIntoConstraints(false)
+		userInteractionEnabled = false
+		setInitialValues()
+	}
+	
     override public class func layerClass() -> AnyClass {
         return KDCircularProgressViewLayer.self
     }


### PR DESCRIPTION
Resolves #4.  I verified that this enabled the ability to drag a view onto a Storyboard, set its class to KDCircularProgress, and run it without crashing - everything checked out!