### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ view.addSubview(progress)
 ```
 
 ## Installation
-- It's on Cocoapods under the name (you guessed it!) KDCircularProgress
+- It's on CocoaPods under the name (you guessed it!) KDCircularProgress
 - Just drag `KDCircularProgress.swift` into your project. `Carthage` support is on To-do list.
 
 ## Properties
@@ -132,7 +132,7 @@ Prefering light colors in the gradients gives better results. As mentioned befor
 ##To-Do
 - [x] Add example project
 - [ ] Carthage Support
-- [x] Cocoapods Support
+- [x] CocoaPods Support
 - [x] IBDesignable/IBInspectable support
 - [ ] Adding a `progress` property as an alternative to `angle`
 - [ ] Clean up


### PR DESCRIPTION

This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>
<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>

Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
