### PR TITLE
converted to swift 2.3 and fixed auto correct with context

### DIFF
--- a/KDCircularProgress/KDCircularProgress.swift
+++ b/KDCircularProgress/KDCircularProgress.swift
@@ -13,7 +13,7 @@ public enum KDCircularProgressGlowMode {
 }
 
 @IBDesignable
-public class KDCircularProgress: UIView {
+public class KDCircularProgress: UIView,CAAnimationDelegate {
     
     private struct Conversion {
         static func degreesToRadians (value:CGFloat) -> CGFloat {
@@ -291,7 +291,7 @@ public class KDCircularProgress: UIView {
     }
     
     public func pauseAnimation() {
-        guard let presentationLayer = progressLayer.presentationLayer() as? KDCircularProgressViewLayer else { return }
+        guard let presentationLayer = progressLayer.presentationLayer() else { return }
         let currentValue = presentationLayer.angle
         progressLayer.removeAllAnimations()
         animationCompletionBlock = nil
@@ -308,10 +308,10 @@ public class KDCircularProgress: UIView {
         return progressLayer.animationForKey("angle") != nil
     }
     
-    override public func animationDidStop(anim: CAAnimation, finished flag: Bool) {
+    public func animationDidStop(anim: CAAnimation, finished flag: Bool) {
         if let completionBlock = animationCompletionBlock {
             if flag {
-               animationCompletionBlock = nil
+                animationCompletionBlock = nil
             }
             
             completionBlock(flag)
@@ -439,28 +439,34 @@ public class KDCircularProgress: UIView {
             CGContextDrawPath(ctx, .FillStroke)
             
             UIGraphicsBeginImageContextWithOptions(size, false, 0.0)
-            
-            let imageCtx = UIGraphicsGetCurrentContext()
             let reducedAngle = Utility.mod(angle, range: 360, minMax: (0, 360))
-            let fromAngle = Conversion.degreesToRadians(CGFloat(-startAngle))
-            let toAngle = Conversion.degreesToRadians(CGFloat((clockwise == true ? -reducedAngle : reducedAngle) - startAngle))
             
-            CGContextAddArc(imageCtx, width/2.0, height/2.0, arcRadius, fromAngle, toAngle, clockwise == true ? 1 : 0)
-            
-            let glowValue = GlowConstants.glowAmountForAngle(reducedAngle, glowAmount: glowAmount, glowMode: glowMode, size: width)
-            if glowValue > 0 {
-                CGContextSetShadowWithColor(imageCtx, CGSizeZero, glowValue, UIColor.blackColor().CGColor)
+            if let imageCtx = UIGraphicsGetCurrentContext(){
+                let fromAngle = Conversion.degreesToRadians(CGFloat(-startAngle))
+                let toAngle = Conversion.degreesToRadians(CGFloat((clockwise == true ? -reducedAngle : reducedAngle) - startAngle))
+                
+                CGContextAddArc(imageCtx, width/2.0, height/2.0, arcRadius, fromAngle, toAngle, clockwise == true ? 1 : 0)
+                
+                let glowValue = GlowConstants.glowAmountForAngle(reducedAngle, glowAmount: glowAmount, glowMode: glowMode, size: width)
+                if glowValue > 0 {
+                    CGContextSetShadowWithColor(imageCtx, CGSizeZero, glowValue, UIColor.blackColor().CGColor)
+                }
+                CGContextSetLineCap(imageCtx, roundedCorners == true ? .Round : .Butt)
+                CGContextSetLineWidth(imageCtx, progressLineWidth)
+                CGContextDrawPath(imageCtx, .Stroke)
+                
+                guard let currentGraphicsContext = UIGraphicsGetCurrentContext() else{
+                    return
+                }
+                
+                if let drawMask: CGImageRef = CGBitmapContextCreateImage(currentGraphicsContext){
+                    UIGraphicsEndImageContext()
+                    CGContextSaveGState(ctx)
+                    CGContextClipToMask(ctx, bounds, drawMask)
+                }else{
+                    UIGraphicsEndImageContext()
+                }
             }
-            CGContextSetLineCap(imageCtx, roundedCorners == true ? .Round : .Butt)
-            CGContextSetLineWidth(imageCtx, progressLineWidth)
-            CGContextDrawPath(imageCtx, .Stroke)
-            
-            let drawMask: CGImageRef = CGBitmapContextCreateImage(UIGraphicsGetCurrentContext())!
-            UIGraphicsEndImageContext()
-            
-            CGContextSaveGState(ctx)
-            CGContextClipToMask(ctx, bounds, drawMask)
-            
             //Gradient - Fill
             if !lerpColorMode && colorsArray.count > 1 {
                 let rgbColorsArray: [UIColor] = colorsArray.map { color in // Make sure every color in colors array is in RGB color space
@@ -503,6 +509,7 @@ public class KDCircularProgress: UIView {
                     fillRectWithContext(ctx, color: color)
                 }
             }
+            
             CGContextRestoreGState(ctx)
             UIGraphicsPopContext()
         }

--- a/KDCircularProgress/KDCircularProgress.swift
+++ b/KDCircularProgress/KDCircularProgress.swift
@@ -509,7 +509,6 @@ public class KDCircularProgress: UIView,CAAnimationDelegate {
                     fillRectWithContext(ctx, color: color)
                 }
             }
-            
             CGContextRestoreGState(ctx)
             UIGraphicsPopContext()
         }

--- a/KDCircularProgressExample/KDCircularProgressExample.xcodeproj/project.pbxproj
+++ b/KDCircularProgressExample/KDCircularProgressExample.xcodeproj/project.pbxproj
@@ -174,9 +174,11 @@
 				TargetAttributes = {
 					BC9E75851A8CE4A500B1DF3D = {
 						CreatedOnToolsVersion = 6.1.1;
+						LastSwiftMigration = 0800;
 					};
 					BC9E759A1A8CE4A500B1DF3D = {
 						CreatedOnToolsVersion = 6.1.1;
+						LastSwiftMigration = 0800;
 						TestTargetID = BC9E75851A8CE4A500B1DF3D;
 					};
 				};
@@ -353,6 +355,7 @@
 				INFOPLIST_FILE = KDCircularProgressExample/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 2.3;
 			};
 			name = Debug;
 		};
@@ -363,6 +366,7 @@
 				INFOPLIST_FILE = KDCircularProgressExample/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 2.3;
 			};
 			name = Release;
 		};
@@ -381,6 +385,7 @@
 				INFOPLIST_FILE = KDCircularProgressExampleTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 2.3;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/KDCircularProgressExample.app/KDCircularProgressExample";
 			};
 			name = Debug;
@@ -396,6 +401,7 @@
 				INFOPLIST_FILE = KDCircularProgressExampleTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 2.3;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/KDCircularProgressExample.app/KDCircularProgressExample";
 			};
 			name = Release;


### PR DESCRIPTION
Used the auto convert, but the context is now optional. So added let checks and guard. Also added the caanimationdelegate to the uiview and removed the override method for animation did stop.