### PR TITLE
Use system default timing (easing) function for animation

### DIFF
--- a/KDCircularProgress/KDCircularProgress.swift
+++ b/KDCircularProgress/KDCircularProgress.swift
@@ -275,6 +275,7 @@ public class KDCircularProgress: UIView, CAAnimationDelegate {
         animation.fromValue = fromAngle
         animation.toValue = toAngle
         animation.duration = animationDuration
+        animation.timingFunction = CAMediaTimingFunction(name: kCAMediaTimingFunctionDefault)
         animation.delegate = self
         animation.isRemovedOnCompletion = false
         angle = toAngle


### PR DESCRIPTION
This makes the animation function look a little bit nicer. A more complete implementation would allow using a custom timing function via a property or argument, but this is a nice start.

I would be cautious merging this change though... users of this project might not appreciate the unexpected change in animation style. But on the other hand it's not a huge change and it's pretty clearly superior.