### PR TITLE
Fix issue with Objective C compatibility in Xcode 9.3

### DIFF
--- a/KDCircularProgress/KDCircularProgress.swift
+++ b/KDCircularProgress/KDCircularProgress.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-public enum KDCircularProgressGlowMode {
+@objc public enum KDCircularProgressGlowMode: Int {
     case forward, reverse, constant, noGlow
 }
 


### PR DESCRIPTION
Xcode 9.3 wont allow non @objc enums to be used as @IBInspectable properties.