### PR TITLE
Expose KDCircularProgressGlowMode to Obj-C.

### DIFF
--- a/KDCircularProgress/KDCircularProgress.swift
+++ b/KDCircularProgress/KDCircularProgress.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-public enum KDCircularProgressGlowMode {
+@objc public enum KDCircularProgressGlowMode: Int {
     case forward, reverse, constant, noGlow
 }
 


### PR DESCRIPTION
Using this library in a new project generates a "Property cannot be marked @IBInspectable because its type cannot be represented in Objective-C" error.

This change exposes the enum KDCircularProgressGlowMode to Obj-C, and changes its raw type to Int as per the requirement.