### PR TITLE
Remove padding from radius if glowMode is set to .noGlow

### DIFF
--- a/KDCircularProgress/KDCircularProgress.swift
+++ b/KDCircularProgress/KDCircularProgress.swift
@@ -152,11 +152,11 @@ public class KDCircularProgress: UIView, CAAnimationDelegate {
     
     public override func layoutSubviews() {
         super.layoutSubviews()
-        radius = (frame.size.width / 2.0) * 0.8
+        radius = (frame.size.width / 2.0) * (glowMode == .noGlow ? 1.0 :0.8)
     }
     
     private func setInitialValues() {
-        radius = (frame.size.width / 2.0) * 0.8 //We always apply a 20% padding, stopping glows from being clipped
+        radius = (frame.size.width / 2.0) * (glowMode == .noGlow ? 1.0 :0.8) //We always apply a 20% padding, stopping glows from being clipped
         backgroundColor = .clear
         set(colors: .white, .cyan)
     }


### PR DESCRIPTION
> We always apply a 20% padding, stopping glows from being clipped

If there is no glow set, a 20% padding only makes the progress radius appear smaller than intended.