### PR TITLE
fixing crash iOS 9

### DIFF
--- a/KDCircularProgress/KDCircularProgress.swift
+++ b/KDCircularProgress/KDCircularProgress.swift
@@ -135,8 +135,8 @@ public class KDCircularProgress: UIView, CAAnimationDelegate {
         set(colors: colors)
     }
     
-    required public init(coder aDecoder: NSCoder) {
-        super.init(coder: aDecoder)!
+    required public init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
         translatesAutoresizingMaskIntoConstraints = false
         setInitialValues()
         refreshValues()


### PR DESCRIPTION
The init `coder` is crashing on iOS 9 because of `!` at `super.init` 