### PR TITLE
Fix the build settings of the example

### DIFF
--- a/Example/iOS Example/iOS Example.xcodeproj/project.pbxproj
+++ b/Example/iOS Example/iOS Example.xcodeproj/project.pbxproj
@@ -350,6 +350,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "iOS Example/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.kaandedeoglu.KDCircularProgress.iOS-Example";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -364,6 +365,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "iOS Example/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.kaandedeoglu.KDCircularProgress.iOS-Example";
 				PRODUCT_NAME = "$(TARGET_NAME)";


### PR DESCRIPTION
Hi,

This PR updates the deployment target of the example to resolve the following compile error:

```
Compiling for iOS 10.0, but module 'KDCircularProgress' has a minimum deployment target of iOS 11.0
```